### PR TITLE
包振丰 201732120111 DaoCloud CI with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.6
+RUN mkdir /project
+ADD ./ /project
+WORKDIR /project
+RUN pip install -r requirements.txt -i https://pypi.mirrors.ustc.edu.cn/simple/
+CMD python service.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask==1.1.1
+Flask_SQLalchemy==2.4.1
+SQLalchemy==1.3.11
+Werkzeug==0.16.0
+uwsgi==2.0.18

--- a/service.py
+++ b/service.py
@@ -688,7 +688,7 @@ def author(author_id):
     return render_template('author.html', articles=articles, comments=comments, Tool=Tool)
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(host='0.0.0.0',port='8000',debug=True)
 
 
 

--- a/service.py
+++ b/service.py
@@ -111,6 +111,8 @@ class Admin(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     email = db.Column(db.String(50), nullable=False)
     password = db.Column(db.String(50), nullable=False)
+    
+db.create_all()
 # ==============================================================================================
 # Tool class include some usual methods
 # ==============================================================================================


### PR DESCRIPTION
I tried circle Ci, but the support of circle CI for docker image publishing may be obscure. I didn't find a very simple way to automatically package the project to generate a docker image and publish it to my ECs. So after many failed attempts, I turned to the domestic container cloud platform: DaoCloud. I found that DaoCloud is more convenient for docker image deployment.

But I need admin permission to bind the project to DaoCloud!!!! Otherwise, DaoCloud cannot capture the push operation on the project.

I've done some experiments on fork before, which seems feasible, although a little rough.